### PR TITLE
Bug 1232245 - Use GitHub instead of SVN as localization source

### DIFF
--- a/scripts/export-base.sh
+++ b/scripts/export-base.sh
@@ -11,7 +11,7 @@ if [ -d firefox-ios-l10n ]; then
 fi
 
 # Check out a clean copy of the l10n repo
-svn co https://svn.mozilla.org/projects/l10n-misc/trunk/firefox-ios firefox-ios-l10n
+git clone https://github.com/mozilla-l10n/firefoxios-l10n firefox-ios-l10n
 
 # Export English base to /tmp/en.xliff
 rm -f /tmp/en.xliff
@@ -26,4 +26,4 @@ fi
 cp /tmp/en.xliff firefox-ios-l10n/en-US/firefox-ios.xliff
 
 # Show what has changed
-(cd firefox-ios-l10n && svn status)
+(cd firefox-ios-l10n && git status)

--- a/scripts/export-locales.sh
+++ b/scripts/export-locales.sh
@@ -3,7 +3,7 @@
 #
 # Assumes the following is installed:
 #
-#  svn
+#  git
 #  brew
 #  python via brew
 #  virtualenv via pip in brew
@@ -30,7 +30,7 @@ brew install libxml2 || exit 1
 STATIC_DEPS=true pip install lxml || exit 1
 
 # Check out a clean copy of the l10n repo
-svn co https://svn.mozilla.org/projects/l10n-misc/trunk/firefox-ios firefox-ios-l10n || exit 1
+git clone https://github.com/mozilla-l10n/firefoxios-l10n firefox-ios-l10n firefox-ios-l10n || exit 1
 
 # Export English base to /tmp/en.xliff
 rm -f /tmp/en.xliff || exit 1

--- a/scripts/export-xliff.py
+++ b/scripts/export-xliff.py
@@ -5,7 +5,7 @@
 #
 #  Export all locales that are present in the l10n directory. We use xcodebuild
 #  to export and write to l10n-directory/$locale/firefox-ios.xliff so that it
-#  can be easily imported into svn. (which is a manual step)
+#  can be easily imported into Git (which is a manual step).
 #
 # Example:
 #

--- a/scripts/import-locales.sh
+++ b/scripts/import-locales.sh
@@ -6,15 +6,13 @@ if [ ! -d Client.xcodeproj ]; then
 fi
 
 if [ -d firefox-ios-l10n ]; then
-  if [ -d firefox-ios-l10n/.svn ]; then
-    echo "deleting existng firefox-ios-l10n svn repo"
+  if [ -d firefox-ios-l10n/.git ]; then
+    echo "Deleting existing firefox-ios-l10n Git repo"
     rm -r firefox-ios-l10n
-    svn co --non-interactive --trust-server-cert https://svn.mozilla.org/projects/l10n-misc/trunk/firefox-ios firefox-ios-l10n || exit 1
   fi
-fi 
-echo "creating firefox-ios-l10n svn repo"
-svn co --non-interactive --trust-server-cert https://svn.mozilla.org/projects/l10n-misc/trunk/firefox-ios firefox-ios-l10n || exit 1
-
+fi
+echo "Creating firefox-ios-l10n Git repo"
+git clone https://github.com/mozilla-l10n/firefoxios-l10n firefox-ios-l10n || exit 1
 
 #
 # TODO Add incomplete locales here that are NOT to be included.
@@ -53,4 +51,3 @@ scripts/xliff-to-strings.py firefox-ios-l10n localized-strings|| exit 1
 
 # Modify the Xcode project to reference the strings files we just created
 scripts/strings-import.py Client.xcodeproj localized-strings || exit 1
-


### PR DESCRIPTION
Note: this can be reviewed, but merge will need to wait until we’re sure all tools are [ready to go](https://bugzilla.mozilla.org/show_bug.cgi?id=1232241).
