### PR TITLE
Bug 1232245 - don't commit l10n repo

### DIFF
--- a/scripts/localise.sh
+++ b/scripts/localise.sh
@@ -15,7 +15,10 @@ scripts/import-locales.sh $1 || exit 1
 echo "Deactivating virtualenv"
 deactivate
 
-git add firefox-ios-l10n Client/*.lproj Extensions/*/*.lproj Client.xcodeproj/project.pbxproj || exit 1
+echo "Committing localised files"
+git status
+git add Client/*.lproj Extensions/*/*.lproj Client.xcodeproj/project.pbxproj || exit 1
 git commit -m 'Import localized files' || exit 1
+git status
 
 cd fastlane


### PR DESCRIPTION
After the move to git for the l10n repo checking the repo in to firefox-ios doesn't really work as then it becomes a modified submodule. Moving to no longer checking in the repo as I don't think we really need it.
