### PR TITLE
Bug 1270859 - Refactored Fastlane scripts to have Nightly/Beta/Release channels

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,16 +1,38 @@
+# Old
+
 app_identifier "org.mozilla.ios.Firefox" # The bundle identifier of your app
 team_id '43AQ936H96'
 
+for_lane :enterprise do
+  team_id '9G8J6YA743'
+end
+
 for_lane :aurora do
-	team_id '9G8J6YA743' 
+	team_id '9G8J6YA743'
 	app_identifier 'org.mozilla.ios.FennecAurora'
 end
 
 for_lane :l10n do
-	team_id '9G8J6YA743' 
+	team_id '9G8J6YA743'
 	app_identifier 'org.mozilla.ios.FennecAurora'
 end
 
 for_lane :fennec do
 	app_identifier 'org.mozilla.ios.Fennec'
+end
+
+# New
+
+team_id '43AQ936H96'
+
+for_lane :nightly do
+  app_identifier "org.mozilla.ios.FirefoxNightly"
+end
+
+for_lane :beta do
+  app_identifier "org.mozilla.ios.FirefoxBeta" 
+end
+
+for_lane :release do
+  app_identifier "org.mozilla.ios.Firefox"
 end

--- a/fastlane/BaseFastfile
+++ b/fastlane/BaseFastfile
@@ -1,18 +1,173 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 fastlane_version "1.39.0"
 
 default_platform :ios
 
-
 platform :ios do
-  before_all do 
+  before_all do
     # make builds & prov profile dirs
     sh("./scripts/mkdirs.sh")
     ensure_git_status_clean()
   end
+
+  after_all do |lane|
+    reset_git_repo(force: true)
+  end
+
+  error do |lane, exception|
+    reset_git_repo(force: true)
+  end
+
+  desc "Creates a Firefox Nightly build for TestFlight. Takes the following arguments: \"
+  :username           Apple ID to fetch data from iTunes connect and sign builds with."
+  lane :nightly do |options|
+    update_build_number_to_next(username: options[:username])
+
+    build_name = "FirefoxNightly-v#{get_version_number}b#{get_build_number}"
+
+    add_badge(color: "blue")
+
+    carthage(platform: "iOS", use_binaries: false)
+
+    sh("../scripts/localise.sh")
+
+    gym(
+      scheme: "FirefoxNightly",
+      output_directory: "./builds/",
+      output_name: "#{build_name}.ipa",
+      sdk: "iphoneos",
+      clean: true,
+      export_method: "app-store",
+      include_symbols: true,
+      include_bitcode: true,
+      use_legacy_build_api: true
+    )
+
+    git_tagify(
+      tag_name: build_name
+    )
+
+    pilot(
+      username: options[:username],
+      ipa: "./builds/#{build_name}.ipa"
+    )
+  end
+
+  desc "Creates a Firefox Beta build for TestFlight. Takes the following arguments: \"
+  :username             Apple ID to fetch data from iTunes connect and sign builds with. \"
+  :adjust_sandbox_key   Adjust API Key for sandbox environment."
+  lane :beta do |options|
+    update_build_number_to_next(username: options[:username])
+
+    build_name = "FirefoxBeta-v#{get_version_number}b#{get_build_number}"
+
+    add_badge(color: "orange")
+
+    carthage(platform: "iOS", use_binaries: false)
+
+    configure_adjust(
+      config: "FirefoxBeta",
+      environment: "sandbox",
+      app_token: options[:adjust_sandbox_key]
+    )
+
+    sh("../scripts/localise.sh")
+
+    gym(
+      scheme: "FirefoxBeta",
+      output_directory: "./builds/",
+      output_name: "#{build_name}.ipa",
+      sdk: "iphoneos",
+      clean: true,
+      export_method: "app-store",
+      include_symbols: true,
+      include_bitcode: true,
+      use_legacy_build_api: true
+    )
+
+    git_tagify(
+      tag_name: build_name
+    )
+
+    pilot(
+      username: options[:username],
+      ipa: "./builds/#{build_name}.ipa",
+      skip_submission: true
+    )
+  end
+
+  desc "Creates a Firefox Release build for TestFlight. Takes the following arguments: \"
+  :username                Apple ID to fetch data from iTunes connect and sign builds with. \"
+  :adjust_production_key   Adjust API Key for production."
+  lane :release do |options|
+    update_build_number_to_next(username: options[:username])
+
+    build_name = "Firefox-v#{get_version_number}b#{get_build_number}"
+
+    carthage(platform: "iOS", use_binaries: false)
+
+    configure_adjust(
+      config: "Firefox",
+      environment: "production",
+      app_token: options[:adjust_production_key]
+    )
+
+    sh("../scripts/localise.sh --release")
+
+    gym(
+      scheme: "Firefox",
+      output_directory: "./builds/",
+      output_name: "#{build_name}.ipa",
+      sdk: "iphoneos",
+      clean: true,
+      export_method: "app-store",
+      include_symbols: true,
+      include_bitcode: true,
+      use_legacy_build_api: true
+    )
+
+    git_tagify(
+      tag_name: build_name
+    )
+
+    pilot(
+      username: options[:username],
+      ipa: "./builds/#{build_name}.ipa",
+      skip_submission: true
+    )
+  end
+
+  desc "Adds the version/build tag on top of the AppIcon. Takes the following arguments: \"
+  :color              The color of the right area of the badge."
+  private_lane :add_badge do |options|
+    badge(
+      shield: "#{get_version_number}-Build%20#{get_build_number}-#{options[:color]}",
+      no_badge: true,
+      shield_no_resize: true
+    )
+  end
+
+  desc "Updates the project's build number to be the next number acceptable by TestFlight. Takes the following arguments: \"
+  :username             Apple ID to use to talk to iTunes Connect with."
+  private_lane :update_build_number_to_next do |options|
+    # Step 1: Update the version and configuration information
+    latest_build_number = latest_testflight_build_number(
+      version: get_version_number,
+      username: options[:username],
+      initial_build_number: 0
+    )
+
+    build_number = latest_build_number + 1
+    increment_build_number(
+      build_number: build_number,
+      xcodeproj: 'Client.xcodeproj'
+    )
+  end
+
+  
 
   private_lane :setup do |options|
     puts "Setup: #{options}\n"
@@ -69,7 +224,7 @@ platform :ios do
       increment_version_number(
         version_number: ENV["APP_VERSION"],
         xcodeproj: 'Client.xcodeproj',
-      ) 
+      )
       version_bumped = true
     end
 
@@ -87,9 +242,9 @@ platform :ios do
 
     if version_bumped == true
       commit_version_bump(
-        message: 'Version Bump', 
-        xcodeproj: 'Client.xcodeproj', 
-      ) 
+        message: 'Version Bump',
+        xcodeproj: 'Client.xcodeproj',
+      )
     end
   end
 
@@ -165,71 +320,6 @@ platform :ios do
     enterprise_build(options: options)
   end
 
-  desc "Builds an beta build for the Firefox channel. Takes the following arguments: \n \
-  :build                the build number for this build. Defaults to current build number \n \
-  :version              the version number for this build. Defaults to current version number \n \
-  :branch               the branch to build (will create if doesn't already exist. A new branch with a predictable username will \
-    be created if this is not provided) \n \
-  :base_branch          the branch with off of which the build should be based (current branch if empty) \n \
-  :build_name           the name of the resultant build. Defaults to firefox-ios-l10n-<:version>-<:build>-<timestamp> \n \
-  :username             the Apple ID to use to log into the developer portal for SIGH \n \
-  :localise             if true, the branch will be localised. If absent or false no localisation will occur \n \
-  :changelog            the path to the changelog for the beta build \n \
-  :adjust_environment   the environment to setup Adjust for \n \
-  :adjust_app_token     the app token for Adjust"
-  lane :beta do |options|
-    options = options[:options] || options
-    puts "beta: #{options}\n"
-    setup(options: options,
-      localise_only_complete: true)
-
-    username = options[:username] || "ios-builds@mozilla.com"
-    sh("sigh download_all -u #{username} --output_path '../provisioning-profiles/'")
-
-    scheme = options[:scheme] || "FirefoxBeta"
-    gym(scheme: scheme,
-      output_directory: "./builds/",
-      output_name: "#{ENV["BUILD_NAME"]}.ipa",
-      sdk: "iphoneos",
-      clean: true,
-      export_method: "app-store",
-      include_symbols: true,
-      include_bitcode: false,
-      use_legacy_build_api: true)
-
-    changelog = ""
-    if options[:changelog] == true
-      File.open(options[:changelog], "r") do |f|
-        f.each_line do |line|
-          changelog += line
-        end
-      end
-    end
-
-    pilot(ipa: "./builds/#{ENV["BUILD_NAME"]}.ipa",
-      skip_submission: true,
-      changelog: changelog)
-
-    reset_git_repo()
-  end
-
-  desc "Builds an beta build for the Fennec channel. Takes the following arguments: \n \
-  :build            the build number for this build. Defaults to current build number \n \
-  :version          the version number for this build. Defaults to current version number \n \
-  :branch           the branch to build (will create if doesn't already exist. A new branch with a predictable username will \
-    be created if this is not provided) \n \
-  :base_branch      the branch with off of which the build should be based (current branch if empty) \n \
-  :build_name       the name of the resultant build. Defaults to firefox-ios-l10n-<:version>-<:build>-<timestamp> \n \
-  :username         the Apple ID to use to log into the developer portal for SIGH \n \
-  :localise         if true, the branch will be localised. If absent or false no localisation will occur \n \
-  :changelog        the path to the changelog for the beta build"
-  lane :fennec do |options|
-    options = options[:options] || options
-    options[:scheme] = "FennecAurora"
-    puts "fennec: #{options}\n"
-    beta(options: options)
-  end
-
   desc "Uploads an ipa. Takes the following arguments: \n \
   :build            the build number for this build \n \
   :version          the version number for this build \n \
@@ -288,7 +378,7 @@ platform :ios do
   :output_directory - the directory to output the snapshots to"
   lane :snapshotL10n do |options|
     if options[:devices]
-      devices = options[:devices].split(",") 
+      devices = options[:devices].split(",")
     else
       devices = ["iPhone 4s", "iPhone 5s", "iPhone 6s", "iPhone 6s Plus", "iPad 2", "iPad Pro"]
     end
@@ -332,7 +422,7 @@ platform :ios do
       output_file = "#{language}/screenshots.html"
       output_links << "<li><a href='#{output_file}'>#{language}</a></li>\n"
       Helper.log.debug "Creating snapshots for #{language} in #{language_dir}/screenshots.html"
-    end 
+    end
     Helper.log.debug "all screenshots: #{output_links}"
     # create (from a template) a new HTML file in options[:output_directory] || "./fastlane/screenshots" to index all language files
     index_html = ""
@@ -345,11 +435,5 @@ platform :ios do
     File.open("#{output_dir}/index.html", 'w') {|f| f.write(index_html) }
     Helper.log.info "Snapshot Index can be found at #{output_dir}/index.html"
     sh("open #{output_dir}/index.html")
-  end
-
-  after_all do |lane|
-  end
-
-  error do |lane, exception|
   end
 end

--- a/fastlane/actions/configure_adjust.rb
+++ b/fastlane/actions/configure_adjust.rb
@@ -13,18 +13,18 @@ module Fastlane
     class ConfigureAdjustAction < Action
       def self.run(params)
         Helper.log.info "Configuring Adjust for:"
-        Helper.log.info "  Target:      #{params[:target]} "
+        Helper.log.info "  Config:      #{params[:config]} "
         Helper.log.info "  Environment: #{params[:environment]} "
         Helper.log.info "  App Token:   #{params[:app_token]} "
 
         environmentKey = "ADJUST_ENVIRONMENT"
         appTokenKey = "ADJUST_APP_TOKEN"
-        
+
         # TODO(sleroux):  Ugh, regex. Replace with .xcconfig file parser if I can find one.
         environmentRegex = "\\(^#{environmentKey}.*\\)"
         appTokenRegex = "\\(^#{appTokenKey}.*\\)"
 
-        xcconfigFilename = "Client/Configuration/#{params[:target]}.xcconfig"
+        xcconfigFilename = "Client/Configuration/#{params[:config]}.xcconfig"
 
         sh("sed -i '' 's/#{environmentRegex}/#{environmentKey} = #{params[:environment]}/g' #{xcconfigFilename}")
         sh("sed -i '' 's/#{appTokenRegex}/#{appTokenKey} = #{params[:app_token]}/g' #{xcconfigFilename}")
@@ -45,15 +45,15 @@ module Fastlane
       end
 
       def self.available_options
-        # Define all options your action supports. 
-        
+        # Define all options your action supports.
+
         # Below a few examples
         [
-          FastlaneCore::ConfigItem.new(key: :target,
-                                       env_name: "FL_CONFIGURE_ADJUST_TARGET_NAME", # The name of the environment variable
+          FastlaneCore::ConfigItem.new(key: :config,
+                                       env_name: "FL_CONFIGURE_ADJUST_CONFIG_NAME", # The name of the environment variable
                                        description: "Name of the .xcconfig to configure Adjust with", # a short description of this parameter),
                                        is_string: true,
-                                       optional: false 
+                                       optional: false
                                        ),
           FastlaneCore::ConfigItem.new(key: :environment,
                                        env_name: "FL_CONFIGURE_ADJUST_ENVIRONMENT_NAME",
@@ -82,13 +82,13 @@ module Fastlane
 
       def self.is_supported?(platform)
         # you can do things like
-        # 
+        #
         #  true
-        # 
+        #
         #  platform == :ios
-        # 
+        #
         #  [:ios, :mac].include?(platform)
-        # 
+        #
 
         platform == :ios
       end

--- a/fastlane/actions/git_tagify.rb
+++ b/fastlane/actions/git_tagify.rb
@@ -1,0 +1,74 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      CONFIGURE_GIT_TAGIFY_CUSTOM_VALUE = :CONFIGURE_GIT_TAGIFY_CUSTOM_VALUE
+    end
+
+    class GitTagifyAction < Action
+      def self.run(params)
+        # Remember which branch we started from
+        old_branch = sh("git rev-parse --abbrev-ref HEAD")
+
+        # Create a temp branch to add our files to
+        sh("git checkout -b temp_#{params[:tag_name]}")
+
+        # Force add our Carthage dependencies
+        sh("git add -f Carthage")
+
+        # Add everything else
+        sh("git add .")
+
+        sh("git commit -m '#{params[:tag_name]} Release Snapshot'")
+
+        # Tag everything up
+        sh("git tag #{params[:tag_name]}")
+
+        # Restore original branch
+        sh("git checkout #{old_branch}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Checks out a temporary branch, adds all unchecked files and produces a tag to push to Github."
+      end
+
+      def self.details
+        "This action will checkout a new branch named after the tag, add all uncommited files to Git, then produce "\
+        "a tag which is pushed to Github. Afterwards, the branch is deleted and the user is restored to the original "\
+        "branch they were on. This allows tags to contains a snapshot of all dependencies for a particular build without "
+        "producing commits on release branches with the additional work done by Fastlane."
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :tag_name,
+                                       env_name: "FL_GIT_TAGIFY_TAG_NAME",
+                                       description: "Name of tag to create and push to Github",
+                                       is_string: true,
+                                       optional: false
+                                       )
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+      end
+
+      def self.authors
+        ["mozilla"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/scripts/localise.sh
+++ b/scripts/localise.sh
@@ -1,10 +1,10 @@
 cd ..
 echo "Activating virtualenv"
 # create/activate virtualenv
-virtualenv -p /usr/bin/python2.7 python-env || exit 1
+virtualenv python-env --python=python2.7 || exit 1
 source python-env/bin/activate || exit 1
 # install libxml2
-STATIC_DEPS=true LIBXML2_VERSION=2.9.2 pip install lxml || exit 1
+CFLAGS=-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/libxml2 LIBXML2_VERSION=2.9.2 pip install lxml || exit 1
 #
 # Import locales
 #
@@ -13,10 +13,5 @@ scripts/import-locales.sh $1 || exit 1
 
 echo "Deactivating virtualenv"
 deactivate
-
-echo "Committing localised files"
-git add Client/*.lproj Extensions/*/*.lproj Client.xcodeproj/project.pbxproj || exit 1
-git commit -m 'Import localized files' || exit 1
-
 
 cd fastlane

--- a/scripts/strings-import.py
+++ b/scripts/strings-import.py
@@ -14,6 +14,7 @@ TARGETS = {
     "Client":    {"path": "Client"},
     "ShareTo":   {"path": "Extensions/ShareTo"},
     "SendTo":    {"path": "Extensions/SendTo"},
+    "Today":     {"path": "Extensions/Today"},
     "ViewLater": {"path": "Extensions/ViewLater"},
     "Shared":    {"path": "Shared"},
 }

--- a/scripts/xliff-cleanup.py
+++ b/scripts/xliff-cleanup.py
@@ -25,6 +25,7 @@ NS = {'x':'urn:oasis:names:tc:xliff:document:1.2'}
 FILES_TO_KEEP = ('Client/Info.plist',
                  'Extensions/ShareTo/Info.plist',
                  'Extensions/SendTo/Info.plist',
+                 'Extensions/Today/Info.plist',
                  'Extensions/ViewLater/Info.plist')
 
 STRINGS_TO_REMOVE = ('CFBundleDisplayName',

--- a/scripts/xliff-to-strings.py
+++ b/scripts/xliff-to-strings.py
@@ -53,6 +53,7 @@ FILES = [
     "Client/SendTo.strings",
     "Extensions/SendTo/Info.plist",
     "Extensions/ShareTo/ShareTo.strings",
+    "Extensions/Today/Today.strings",
     "Extensions/ViewLater/Info.plist",
     "Shared/Localizable.strings",
 ]


### PR DESCRIPTION
- Fixed localise.sh to work with fixed python version and CFLAGS argument for better lxml building.
- Added git_tagify action to bundle up everything and produce a tag with all the contents we import during the build process for release snapshots.
- Added various improvements to the lanes including badging icons and auto-build number generation from TestFlight
