### PR TITLE
zgh locale code maps to tzm on iOS

### DIFF
--- a/update-xliff.py
+++ b/update-xliff.py
@@ -116,7 +116,8 @@ def main():
             'nb-NO': 'nb',
             'nn-NO': 'nn',
             'sv-SE': 'sv',
-            'tl'   : 'fil'
+            'tl'   : 'fil',
+            'zgh'  : 'tzm'
         }
         if locale_code in locale_mapping:
             locale_code = locale_mapping[locale_code]


### PR DESCRIPTION
Fix for https://github.com/mozilla-mobile/firefox-ios/issues/5509

https://gist.github.com/jacobbubu/1836273#file-ioslocaleidentifiers-csv-L331