### PR TITLE
Fix resource path for Lockwise strings

### DIFF
--- a/export-locales.sh
+++ b/export-locales.sh
@@ -95,7 +95,7 @@ fi
 /usr/bin/perl -p -i -e "s|OpenInFocus/en.lproj/InfoPlist.strings|OpenInFocus/InfoPlist.strings|g" /tmp/en.xliff
 /usr/bin/perl -p -i -e "s|CredentialProvider/en.lproj/InfoPlist.strings|CredentialProvider/InfoPlist.strings|g" /tmp/en.xliff
 /usr/bin/perl -p -i -e "s|CredentialProvider/en.lproj/Localizable.strings|CredentialProvider/Localizable.strings|g" /tmp/en.xliff
-/usr/bin/perl -p -i -e "s|lockbox-ios/Common/Resources/en.lproj/InfoPlist.strings|lockbox-ios/Common/Resources/InfoPlist.strings|g" /tmp/en.xliff
+/usr/bin/perl -p -i -e "s|lockbox-ios/Common/Resources/Strings/en.lproj/InfoPlist.strings|lockbox-ios/Common/Resources/Strings/InfoPlist.strings|g" /tmp/en.xliff
 /usr/bin/perl -p -i -e "s|lockbox-ios/Common/Resources/Strings/en.lproj/Localizable.strings|lockbox-ios/Common/Resources/Strings/Localizable.strings|g" /tmp/en.xliff
 
 


### PR DESCRIPTION
Discussed at https://github.com/mozilla-l10n/lockwiseios-l10n/pull/5

@kaylagalway for now this is the branch to switch to when _exporting_